### PR TITLE
Solved issue when trying to run the application FatJar file that occu…

### DIFF
--- a/libreguardia.ktor/build.gradle.kts
+++ b/libreguardia.ktor/build.gradle.kts
@@ -26,6 +26,12 @@ tasks.withType<ProcessResources> {
     duplicatesStrategy = DuplicatesStrategy.WARN
 }
 
+tasks.shadowJar {
+    mergeServiceFiles{
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+}
+
 kotlin {
     jvmToolchain(21)
 }


### PR DESCRIPTION
…rred because flyway and flyway-postgresql dependency contains a meta-inf service file with same name and location, so when you build a jar a conflict occurs and the flyway-postgres service file is kept and the flyaway-core service file is discarded/gets overwritten by default.

I solved the error by searching it: https://stackoverflow.com/questions/79864003/after-upgrade-flyway-initialization-fails-with-unknown-prefix-for-location